### PR TITLE
fix busted rge documentation links

### DIFF
--- a/rge/customization.md
+++ b/rge/customization.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/edit/master/rge/readme.md#Customization)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#Customization)
 
 ## Customization
 

--- a/rge/installation.md
+++ b/rge/installation.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/edit/master/rge/readme.md#Installation)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#Installation)
 
 ## Installation
 

--- a/rge/mcm.md
+++ b/rge/mcm.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#MCM%20Configuration)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#mcm-configuration)
 
 ## MCM Configuration
 

--- a/rge/mcm.md
+++ b/rge/mcm.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/edit/master/rge/readme.md#MCM)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#MCM)
 
 ## MCM Configuration
 

--- a/rge/mcm.md
+++ b/rge/mcm.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#MCM)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#MCM%20Configuration)
 
 ## MCM Configuration
 

--- a/rge/mods.md
+++ b/rge/mods.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#mods)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#mod-information)
 
 ## Mod Information
 

--- a/rge/mods.md
+++ b/rge/mods.md
@@ -1,4 +1,4 @@
-[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/edit/master/rge/readme.md#mods)
+[Back to Main Documentation](https://github.com/wabbajack-tools/mod-lists/blob/master/rge/readme.md#mods)
 
 ## Mod Information
 


### PR DESCRIPTION
Sorry for the multiple commits to master... the links flopped me out onto the main branch and I didnt' realize while editing.  Awkward.