### PR TITLE
Update modlists.json

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -269,23 +269,23 @@
   {
     "title": "Keizaal",
     "description": "Keizaal is a simple modlist that seeks to enhance and expand on Skyrim without compromising Bethesda’s original vision. It also aims to maintain a level of consistency between the base game and Beyond Skyrim projects in order to make Tamriel feel like one cohesive whole.",
-    "version": "2.5.8",
+    "version": "2.5.9",
     "author": "Pierre Despereaux",
     "game": "skyrimspecialedition",
     "tags": ["Official"],
     "links": {
       "image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/splash_image.png",
       "readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/readme.md",
-      "download": "https://wabbajackpush.b-cdn.net/Keizaal-dbc6c849-4469-46f5-a8f1-0d5e2d7e1413.wabbajack",
+      "download": "https://wabbajackpush.b-cdn.net/Keizaal-9c66a57d-bdc6-4547-bf0c-f477d0367deb.wabbajack",
       "machineURL": "keizaal"
     },
     "download_metadata": {
-      "Hash": "YMpWq5a5tYM=",
-      "Size": 455568186,
-      "NumberOfArchives": 387,
-      "SizeOfArchives": 50296601851,
-      "NumberOfInstalledFiles": 70406,
-      "SizeOfInstalledFiles": 78667249639
+      "Hash": "VNttRDJAaGs=",
+      "Size": 456282611,
+      "NumberOfArchives": 390,
+      "SizeOfArchives": 50296661024,
+      "NumberOfInstalledFiles": 70505,
+      "SizeOfInstalledFiles": 78675903225
     }
   },
   {


### PR DESCRIPTION
- Added the Vigilant's New Clothes (disabled by default)
- Added Pirate's Life for Me (disabled by default)
- Added Diverse Redguard Clothes (disabled by default)
- Updated Adamant to 2.1.5
- Fixed missing Better Shaped Weapons meshes
- Distributed Chitin Weapons to the Reavers on Solstheim
- Fixed visual bug with the Chitin Sword
- Restricted crafting Beyond Skyrim variants of weapons and armor per province to keep the crafting menu clean
- Removed Beyond Skyrim recipes for items that were impossible to craft
- Restricted Beyond Skyrim Ebony Jewelry to require the Ebony Smithing perk
- Fixed inconsistency between the Cyrodiil Iron Sword and Vanilla Iron Sword