### PR TITLE
Improve widescreen instalation documentation

### DIFF
--- a/magnum_opus/readme.md
+++ b/magnum_opus/readme.md
@@ -143,12 +143,15 @@ That's it! Have fun!
 
 3) Install [DEF_UI HUDMenuSet Ultrawidescreen](https://www.nexusmods.com/fallout4/mods/43277)
 
-Get a standalone Adobe Flash Player from Adobe and install in the same location as HUDMenuSet.swf  
-Execute the standalone Adobe Flash Player and load HUDMenuSet.swf (from here it will work as the DEF_UI HUDMenuSet.exe)  
-Move the UI elements to your liking (or leave as is).  Once satisfied hit Ctrl+S  
+4) Get a standalone Adobe Flash Player from [here](https://www.adobe.com/support/flashplayer/debug_downloads.html) and click "Download the Flash Player projector content debugger"
+
+5) Paste the "flashplayer_32_sa_debug.exe" in the same location as HUDMenuSet.swf  
+
+6) Execute the standalone Adobe Flash Player(the .exe you just downloaded) and load HUDMenuSet.swf (from here it will work as the DEF_UI HUDMenuSet.exe)  
+
+7) Move the UI elements to your liking (or leave as is). Once satisfied hit Ctrl+S  
   *  Note that Magnum Opus already has a custom Def UI preset, aptly titled Lively's HUD Preset. Disable this mod in MO2 if you want to make your own.  
-  
-Create a new folder DEF_CONF in the same location as HUDMenuSet.swf and save the new XML file inside the new folder  
+8) Create a new folder DEF_CONF in the same location as HUDMenuSet.swf and save the new XML file inside the new folder  
 
 #### Crashlogs:  
 

--- a/magnum_opus/readme.md
+++ b/magnum_opus/readme.md
@@ -143,7 +143,7 @@ That's it! Have fun!
 
 3) Install [DEF_UI HUDMenuSet Ultrawidescreen](https://www.nexusmods.com/fallout4/mods/43277)
 
-4) Get a standalone Adobe Flash Player from [here](https://www.adobe.com/support/flashplayer/debug_downloads.html) and click "Download the Flash Player projector content debugger"
+4) Download a [standalone Adobe Flash Player from Adobe] (https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flashplayer_32_sa_debug.exe)
 
 5) Paste the "flashplayer_32_sa_debug.exe" in the same location as HUDMenuSet.swf  
 


### PR DESCRIPTION
This instructions i changed was copied from https://www.nexusmods.com/fallout4/mods/43277?tab=files and was vague and confusing as i saw users in the mod nexus page and in wabbajack discord asking where to download the standalone adobe version or what it is