### PR TITLE
updated Degenreate Dungeon

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -380,13 +380,13 @@
 			"machineURL": "ultimate_skyrim"
 		},
 		"download_metadata": {
-			"Hash": "E6k32oCE7rQ=",
-			"Size": 24954746,
-			"NumberOfArchives": 294,
-			"SizeOfArchives": 13782701731,
-			"NumberOfInstalledFiles": 34561,
-			"SizeOfInstalledFiles": 27690088873
-		}
+			  "Hash": "fo/ZWkOyOEU=",
+  			  "Size": 1857756,
+       		          "NumberOfArchives": 145,
+                          "SizeOfArchives": 5180857671,
+                          "NumberOfInstalledFiles": 31993,
+                          "SizeOfInstalledFiles": 4693197176
+                }
 	},
 	{
 		"title": "GhoulOut",

--- a/modlists.json
+++ b/modlists.json
@@ -354,7 +354,7 @@
 		"links": {
 			"image": "https://raw.githubusercontent.com/AwesomeJames2120/Degenerate-Dungeon/master/Degenerate%20Dungeon.png",
 			"readme": "https://raw.githubusercontent.com/AwesomeJames2120/Degenerate-Dungeon/master/README.md",
-			"download": "https://drive.google.com/file/d/1m8jCSpwK8WnGWmiPieKWky5kuyowhkvx/view?usp=sharing",
+			"download": "https://wabbajack.b-cdn.net/Degenerate%20Dungeon%20-%20More%20Booby.wabbajack_406f83f5-f8fd-4f98-be68-f40d4111e6bb",
 			"machineURL": "degeneratedungeon"
 		},
 		"download_metadata": {


### PR DESCRIPTION
so the .wabbajack download uses the CDN