### PR TITLE
Keizaal 3.3.0

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -504,23 +504,23 @@
 	{
 		"title": "Keizaal",
 		"description": "Keizaal is a simple modlist that seeks to enhance and expand on Skyrim without compromising Bethesda’s original vision that we all fell in love with back in 2011.",
-		"version": "3.2.2",
+		"version": "3.3.0",
 		"author": "Pierre Despereaux",
 		"game": "skyrimspecialedition",
 		"tags": ["Official"],
 		"links": {
 			"image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/splash_image.png",
 			"readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/readme.md",
-			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_eb988540-9429-4d1d-9daf-4127d9bd377b",
+			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_4876ba2d-3b12-4346-b151-5596f1eae6bb",
 			"machineURL": "keizaal"
 		},
 		"download_metadata": {
-			"Hash": "6iOlBWil7SA=",
-			"Size": 218757379,
-			"NumberOfArchives": 460,
-			"SizeOfArchives": 72662862421,
-			"NumberOfInstalledFiles": 59405,
-			"SizeOfInstalledFiles": 104415431710
+			"Hash": "XaUdLym89mM=",
+			"Size": 233167353,
+			"NumberOfArchives": 492,
+			"SizeOfArchives": 74263269561,
+			"NumberOfInstalledFiles": 68510,
+			"SizeOfInstalledFiles": 108386849008
 		}
 	},
 	{


### PR DESCRIPTION
- Updated Mod Organizer 2 to 2.3.2
- Updated SKSE64 to 2.0.19
- Updated Rodryk's Dragon Bridge to 1.0.3
- Updated No Grass in Objects to 3.0.0
- Updated Misc. Blended Road Fixes to 1.1.0
- Added the Shadowscale Set
- Added Beast Hair Horn Beard and Brow
- Added Expanded Towns and Cities
- Added .NET Script Framework
- Added Dark Brotherhood Mask Fix
- Added iEquip (disabled by default in the MCM)
- Added Papyrus Extender
- Added East Empire Company Armor
- Added Trees with Trunks
- Added Moon and Star
- Added Moon and Star Fixes
- Added Beards of Power
- Added QuickLoot
- Added Dlizzio's Mesh Fixes
- Added Smooth Windhelm Ground Meshes
- Added East Empire Strongbox Logo
- Added Rustic Maps
- Added Rustic Amulets
- Added Chill Out Aela
- Added Bring Meeko to Lod
- Added Jagged Crown - Replacer
- Added Keening Rework HD