### PR TITLE
Keizaal 3.4.0

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -1,5 +1,27 @@
 [
 	{
+		"title": "Keizaal",
+		"description": "Keizaal is a simple modlist that seeks to enhance and expand on Skyrim without compromising Bethesda’s original vision that we all fell in love with back in 2011. This list focuses on improving what is already there as opposed to adding a ton of new content and features.",
+		"version": "3.4.0",
+		"author": "Pierre Despereaux",
+		"game": "skyrimspecialedition",
+		"tags": ["Official"],
+		"links": {
+			"image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/splash_image.png",
+			"readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/readme.md",
+			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_61c3d4d3-cc0e-4b12-b193-2d21b10b6ee2",
+			"machineURL": "keizaal"
+		},
+		"download_metadata": {
+			"Hash": "E3JM2H9nvbc=",
+			"Size": 241431500,
+			"NumberOfArchives": 546,
+			"SizeOfArchives": 65353654689,
+			"NumberOfInstalledFiles": 61969,
+			"SizeOfInstalledFiles": 93005687213
+		}
+	},
+	{
 		"title": "Tales from the Northern Lands",
 		"description": "A visually Borderlands inspired Skyrim Overhaul Modlist. Intended to empower the player using SPERG, the True Dragonborn Uncapper Preset and offering ~93.700 weapons and ~91.000 clothing items (Armors, jewelry and clothes) to find.",
 		"version": "1.9.3",


### PR DESCRIPTION
- Added Weapon Speed Effect Fix
- Armor Mesh Fixes
- Added Hjaltbrand
- Added Vastly More Unique Visage of Mzund
- Added Gemling Queen Jewelery
- Added WiZkiD - Hall of the Dead Stained Glass Windows
- Added WiZkiD - Pavo's House
- Added Rally's Butterfiles, Moths, and Torchbugs
- Added Realistic Skin Shaders - Falmer and Hagravens
- Added Realistic Skin Shaders - Giants
- Added Eyes AO Clipping Fix
- Added Improved Eye Reflections
- Added Northborn Scars
- Added Window Shadows
- Added Bee and Bard Unique Drinks
- Adeed Near Vanilla Project - Portal to Sovngarde Redone
- Added Quality Cubemaps
- Added Volcanic Heat Haze
- Added Rally's Raven Rock
- Added Rally's Solstheim Landscapes
- Added Cleaned Skyrim Textures
- Added Scaleform Translation Plus Plus
- Added Equip Enchantment Fix
- Added Classic Sprinting Redone
- Added NPC AI Process Position Fix
- Added Storefront
- Added Favorite Misc Items
- Added Loki's Wade in Water
- Added Creation Club Armor Textures Upscaled
- Added Project Clarity - Effects
- Added Durnehviir Resurrected
- Added Stones of Barzenziah Whereabout
- Added Gildergreen Regrown
- Added Finding Helgi and Laelette
- Added Finding Derkeethus
- Added Finding Susanna Alive
- Added Findng Velehk Sain
- Added Bibliophile's Arcanaeum
- Added Bounty Preview
- Added The Falkreath Hauntings
- Added Simply Knock
- Added Grahl - The Ice Troll
- Added Misc. SMIM Fixes
- Added Bogmort - Swamp Monsters of Morthal
- Updated iEquip to 1.5.1
- Updated Blended Roads Redone to 1.5.1
- Updated No Grass in Object to 5.0.0
- Updated Unoffical Skyrim Creation Club Content Patch to 5.6.0
- Removed Closing Time
- Removed The Decayed Dragon - Durnehviir
- Removed Moon and Star for maintenance
- Removed Expanded Towns and Cities for maintenance
- Alphabetized the entire modlist in MO2 where possible.