### PR TITLE
Keizaal 3.4.2

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -2,23 +2,23 @@
 	{
 		"title": "Keizaal",
 		"description": "Keizaal is a simple modlist that seeks to enhance and expand on Skyrim without compromising Bethesda’s original vision that we all fell in love with back in 2011. This list focuses on improving what is already there as opposed to adding a ton of new content and features.",
-		"version": "3.4.1",
+		"version": "3.4.2",
 		"author": "Pierre Despereaux",
 		"game": "skyrimspecialedition",
 		"tags": ["Official"],
 		"links": {
 			"image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/splash_image.png",
 			"readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/readme.md",
-			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_11c05dac-b57d-438f-b7ab-47e1db12e1a3",
+			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_c19fbccc-f9a3-4f46-a550-5fe3d1c960dc",
 			"machineURL": "keizaal"
 		},
 		"download_metadata": {
-			"Hash": "MsmtS8P1XAU=",
-			"Size": 250102678,
-			"NumberOfArchives": 566,
-			"SizeOfArchives": 66282284764,
-			"NumberOfInstalledFiles": 63944,
-			"SizeOfInstalledFiles": 94765026982
+			"Hash": "YS3KaTLgcbI=",
+			"Size": 208621516,
+			"NumberOfArchives": 599,
+			"SizeOfArchives": 81370243746,
+			"NumberOfInstalledFiles": 71052,
+			"SizeOfInstalledFiles": 122649225544
 		}
 	},
 	{


### PR DESCRIPTION
- Updated Adamant - A Perk Overhaul to 4.2.3
- Updated The Falkreath Hauntings to 2.0.0
- Updated No Grass in Objects to 6.0.0
- Updated Unoffical Skyrim Special Edition Patch to 4.2.4
- Updated all Project Clarity modules
- Updated DynDOLOD to 3.0.0
- Regenned all LODs to high detail with ultra trees.
- Added Essential Favorites
- Added Spice of Life - Orc Longhouses
- Added Difficulty Balance
- Added Tale of Two Mers - An Armor Variant Mod
- Added DVA - Dynamic Vampire Appearance
- Added Telvanni Reborn
- Added Frankly HD Masque of Clavicus Vile
- Added Frankly HD Dawnguard Armor and Weapons
- Added Project Clarity - Statues
- Added Frankly HD Lockpicking Interface
- Added Remiros' Ebony Blade HD
- Added Keening 4K
- Added Skyland AIO
- Added Raven Rock - Fix Exit on Horseback
- Added Dreams's Unique Dogs
- Added Shiny Texture Fix for SRO
- Added Rudy HD - More Lights for ENB
- Added Near Vanilla Project - Temple of Kynareth
- Added Near Vanilla Project - Eye of Magnus
- Added Near Vanilla Project - Portal to Sovngarde
- Added WM's Flora Fixes - Revamped
- Added Perfect Terrain LOD for Skyrim Realistic Overhaul
- Added Unique Horksbane
- Added Relationship Dialogue Overhaul
- Added Guard Dialogue Overhaul
- Added Realistic AI Detection - Lite
- Added Manor Roads
- Added Blackreach Tentacle Mesh Fix
- Added Stockades of Skyrim 3D
- Added Hearthfire Map Marker Fix
- Added Immersive Patrols
- Added Misc Tweaks - No Starting Spells
- Added Misc Tweaks - Outfit Tweaks
- Added Misc Tweaks - Better Horses
- Added Misc Tweaks - Better Ancient Knowledge Perk
- Added Civil War Aftermath
- Added Morrowloot Miscellania - Dremora Bound Weapons
- Added Beast Skeletons - Revised
- Added Better Shrouded Armor SSE - Ancient Replacer Only
- Removed Noble Skyrim
- Removed HD LODs
- Removed Osmodius
- Removed Nordic Locks
- Removed Rally's Tal Mithryn
- Removed Rally's All the Things
- Removed Rally's Solstheim Landscapes
- Removed Rally's Reikling Settlements