### PR TITLE
Keizaal 3.4.5

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -2,7 +2,7 @@
 	{
 		"title": "Keizaal",
 		"description": "Keizaal is a simple modlist that focuses on improving what is already presented to us in vanilla Skyrim without compromising Bethesda’s original vision that we all fell in love with back in 2011.",
-		"version": "3.4.4",
+		"version": "3.4.5",
 		"author": "Pierre Despereaux",
 		"game": "skyrimspecialedition",
 		"image_contains_title": false,
@@ -10,16 +10,16 @@
 		"links": {
 			"image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/splash_image.png",
 			"readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/Keizaal/readme.md",
-			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_a66742b0-a212-4103-88ee-b28db34e7d45",
+			"download": "https://wabbajack.b-cdn.net/Keizaal.wabbajack_88228cb9-e2f5-4063-bee8-1b0a42cecce6",
 			"machineURL": "keizaal"
 		},
 		"download_metadata": {
-			"Hash": "Uhf2t5LfIGc=",
-			"Size": 286811369,
-			"NumberOfArchives": 650,
-			"SizeOfArchives": 86290874896,
-			"NumberOfInstalledFiles": 88292,
-			"SizeOfInstalledFiles": 124059702520
+			"Hash": "Z27VFcM0JvE=",
+			"Size": 288064399,
+			"NumberOfArchives": 660,
+			"SizeOfArchives": 87542045564,
+			"NumberOfInstalledFiles": 103906,
+			"SizeOfInstalledFiles": 132194369182
 		}
 	},
 	{


### PR DESCRIPTION
- Updated Equip Enchantment Fix to 1.2.1
- Updated Unofficial Skyrim Special Edition Patch to 4.2.4b
- Updated Depths of Skyrim to 1.1.7
- Updated Project Clarity - Effects to 2.0.1
- Added Unique Ancient Shrouded Armor
- Added SkyHUD
- Added Jazbay by Mari
- Added Spiky Grass by Mari
- Added Nirnroot buy Nari
- Added Dragons Tongue by Mari
- Added Logical Outfits and Classes for Dark Brotherhood Forever
- Added Oblivion-like Loading Screens
- Added The Elder Scrolls: Legends Loading Screens
- Added UHDAP Replacer for Talkative Dragons
- Added Unique Border Gates
- Added Civil War Intro Scenes Play Once
- Added Cinematic Intro
- Added Yet Another Main Menu
- Added Whiterun Hold Refine
- Added Markarth Side Refine
- Added Stormcloak Rebellion Refine
- Added Housecarl Companions Refine
- Added Natural Teeth
- Added Hallgarth's Additional (Vanilla) Hair
- Added Natural Eyes
- Added WICO - Windsong Immersive Character Overhaul
- Added Skyrim Landscape and Water Fixes
- Added WiZkiD Carriages
- Added Cathedral Player and NPC Overhaul - HMB II
- Added More Werewolves
- Added Unique Stormcloak Gear
- Removed Enhanced Lighting for ENB
- Removed Darker Nights for Obsidian Weathers
- Removed Better Shrouded Armor - Ancient Replacer Only
- Removed Better Telekinesis