### PR TITLE
Updated RGE

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -320,17 +320,17 @@
 		"links": {
 			"image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
 			"readme": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/README.md",
-			"download": "https://wabbajack.b-cdn.net/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_ab5c102f-8a9a-4746-a268-43c29f7adf45",
+			"download": "https://wabbajack.b-cdn.net/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_0e379c47-c04a-48f0-a9b5-a94b65ddc498",
 			"machineURL": "rge"
 		},
 		"download_metadata": {
 			"$type": "DownloadMetadata, Wabbajack.Lib",
-			"Hash": "7EIt9tHxpRI=",
-			"Size": 1388083737,
+			"Hash": "hX0l5HnVQhM=",
+			"Size": 1030089002,
 			"NumberOfArchives": 920,
-			"SizeOfArchives": 95231936771,
-			"NumberOfInstalledFiles": 156382,
-			"SizeOfInstalledFiles": 124365270960
+			"SizeOfArchives": 96503184566,
+			"NumberOfInstalledFiles": 157624,
+			"SizeOfInstalledFiles": 125274434209
 		}
 	},
 	{


### PR DESCRIPTION
Relics of Hyrule updated to 6.6
Number of archives stayed the same. 