### PR TITLE
Update of ES

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -249,17 +249,17 @@
     "links": {
       "image": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/elder_souls/elder-souls.png",
       "readme": "https://raw.githubusercontent.com/GuitarBarbarianOfThunder/eldersouls/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Elder%20Souls.wabbajack_33a09b73-f571-4045-ac72-a6dafc9657be",
+      "download": "https://authored-files.wabbajack.org/Elder%20Souls.wabbajack_a2215b71-dfe8-41f2-b374-3e9524e089dc",
       "machineURL": "eldersouls"
     },
     "download_metadata": {
       "$type": "DownloadMetadata, Wabbajack.Lib",
-      "Hash": "fTI9yTbc9Cg=",
-      "Size": 2625004003,
-      "NumberOfArchives": 1160,
-      "SizeOfArchives": 136010510025,
-      "NumberOfInstalledFiles": 176657,
-      "SizeOfInstalledFiles": 134832427550
+      "Hash": "8/u9TWI8eqo=",
+      "Size": 2625058618,
+      "NumberOfArchives": 1157,
+      "SizeOfArchives": 135860753363,
+      "NumberOfInstalledFiles": 176636,
+      "SizeOfInstalledFiles": 134832354264
     }
   },
   {


### PR DESCRIPTION
Removed Gold to Septims, might put in Khajit Speak later to reintegrate it because its part of that now.