### PR TITLE
RGE 2.2.5

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -289,24 +289,24 @@
   {
     "title": "Relics of Hyrule - GAT Edition",
     "description": "The goal of this modlist is to be something fun and different rather than your 100th enai-survival-rim playthrough. This modlist primarily revolves around Relics of Hyrule and Grand Admiral Thrawn with new monsters coming from a heavily modified version of Rogue-Like Encounters.",
-    "version": "2.2.4.9",
+    "version": "2.2.5",
     "author": "jdsmith2816, maintained by Fantastigasmical Alice",
     "game": "skyrimspecialedition",
     "tags": ["Official"],
     "links": {
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
-      "readme": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/README.md",
+      "readme": "https://github.com/lexcia98/rge/blob/master/README.md",
       "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_d287a34c-e95d-4f22-b409-56656b28cc02/",
       "machineURL": "rge"
     },
     "download_metadata": {
       "$type": "DownloadMetadata, Wabbajack.Lib",
-      "Hash": "aNcoMSlwLwo=",
-      "Size": 683106423,
-      "NumberOfArchives": 944,
-      "SizeOfArchives": 100238793348,
-      "NumberOfInstalledFiles": 173860,
-      "SizeOfInstalledFiles": 130818510635
+      "Hash": "wlG5GAXQRBU=",
+      "Size": 1060987386,
+      "NumberOfArchives": 946,
+      "SizeOfArchives": 100242679490,
+      "NumberOfInstalledFiles": 173963,
+      "SizeOfInstalledFiles": 130832253621
     }
   },
   {

--- a/modlists.json
+++ b/modlists.json
@@ -295,7 +295,7 @@
     "tags": ["Official"],
     "links": {
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
-      "readme": "https://github.com/lexcia98/rge/blob/master/README.md",
+      "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
       "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_d287a34c-e95d-4f22-b409-56656b28cc02/",
       "machineURL": "rge"
     },


### PR DESCRIPTION
RGE Update 2.2.5
Removed
Nether's Follower Framework
EZ2C

Added
Amazing Follower Tweaks
Better Dialogue Controls

Due to changes in 2 mods, a new save is highly recommended and possibly required for this update. Should you already have the list installed, do not feel obligated to update.