### PR TITLE
RGE 2.2.5.2

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -330,19 +330,19 @@
       "$type": "Links, Wabbajack.Lib",
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
       "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_58b238d6-d19b-4f7e-9b3b-157a67e02818",
+      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_cdd780ed-e930-47c6-8aa3-0e8ac8bccbbb",
       "machineURL": "rge"
     },
     "download_metadata": {
       "$type": "DownloadMetadata, Wabbajack.Lib",
-      "Hash": "SU8qaCXXA7o=",
-      "Size": 1068707107,
-      "NumberOfArchives": 945,
-      "SizeOfArchives": 99814328170,
-      "NumberOfInstalledFiles": 173931,
-      "SizeOfInstalledFiles": 130836500419
+      "Hash": "gNkRxGOT4hI=",
+      "Size": 1075286755,
+      "NumberOfArchives": 943,
+      "SizeOfArchives": 99806220167,
+      "NumberOfInstalledFiles": 173916,
+      "SizeOfInstalledFiles": 130838294979
     },
-    "version": "2.2.5.1"
+    "version": "2.2.5.2"
   },
   {
     "$type": "ModListMetadata, Wabbajack.Lib",


### PR DESCRIPTION
Relics of Hyrule - Grand Admiral Thrawn Edition
2.2.5.2 Update
Removed mods: 
Honey pot 1.3b Special Edition-3036-1-3b.7z
Take clam shell Full BAIN and Fomod 3.1SE-7688-3-1.7z