### PR TITLE
Update modlists.json

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -697,19 +697,19 @@
       "$type": "Links, Wabbajack.Lib",
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
       "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_424c7784-8b99-416a-a4eb-08d30dbbd421",
+      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_a390a9ef-a6e1-4183-aae7-ca10da5e6379",
       "machineURL": "rge"
     },
     "download_metadata": {
       "$type": "DownloadMetadata, Wabbajack.Lib",
-      "Hash": "eIde9S8xm9A=",
-      "Size": 936803393,
-      "NumberOfArchives": 939,
-      "SizeOfArchives": 99297180190,
-      "NumberOfInstalledFiles": 176890,
-      "SizeOfInstalledFiles": 128197226157
+      "Hash": "+07RKESp3BE=",
+      "Size": 945051376,
+      "NumberOfArchives": 965,
+      "SizeOfArchives": 99612944425,
+      "NumberOfInstalledFiles": 182214,
+      "SizeOfInstalledFiles": 135847268469
     },
-    "version": "2.2.5.4"
+    "version": "2.2.5.7"
   },
   {
     "$type": "ModListMetadata, Wabbajack.Lib",


### PR DESCRIPTION
Updated RGE
Updated Mods
Relics of Hyrule
Invasion of Skyrim

Fixed
Riverside Shack can now be built.