### PR TITLE
Update modlists.json

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -788,18 +788,18 @@
     "links": {
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
       "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_1ae59c28-6a03-4e84-999c-63fe555623c4",
+      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_445cf140-e054-44c6-9b0c-d5075a6553c5",
       "machineURL": "rge"
     },
     "download_metadata": {
-      "Hash": "LQPoqFNViRs=",
-      "Size": 948711846,
+      "Hash": "x4engdM9Wyk=",
+      "Size": 949519841,
       "NumberOfArchives": 962,
       "SizeOfArchives": 106754206005,
-      "NumberOfInstalledFiles": 182663,
-      "SizeOfInstalledFiles": 144581048996
+      "NumberOfInstalledFiles": 183997,
+      "SizeOfInstalledFiles": 144580966450
     },
-    "version": "2.2.5.10",
+    "version": "2.2.5.11",
     "dateCreated": "1970-01-01T00:00:00Z",
     "dateUpdated": "0001-01-01T00:00:00"
   },


### PR DESCRIPTION
RGE Update 2.2.5.11
Fixed
Hermit's Stump
Tel Mos
Priory Of The Cape
Ravenscale Cabin
Deeds for these dwellings have been given to vendors in holds.