### PR TITLE
Temporarily force down Viva New Vegas

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -332,7 +332,7 @@
     "nsfw": false,
     "utility_list": false,
     "image_contains_title": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "image": "https://raw.githubusercontent.com/TDarkShadow/vivanewvegas-wabbajack/master/background.webp",
       "readme": "https://raw.githubusercontent.com/TDarkShadow/vivanewvegas-wabbajack/master/README.md",


### PR DESCRIPTION
Vanilla UI Plus got updated to v8.86 and force healing documentation hasn't been updated yet.