### PR TITLE
Update modlists.json

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -621,16 +621,16 @@
     "links": {
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
       "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_039a8a92-ebe3-4a92-b431-6a6863d7c4b0",
+      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_e223cf84-e6ca-4368-b278-0ebe392506b7/",
       "machineURL": "rge"
     },
     "download_metadata": {
-      "Hash": "St6gBjVRQpc=",
-      "Size": 1139913913,
-      "NumberOfArchives": 966,
-      "SizeOfArchives": 108995048365,
-      "NumberOfInstalledFiles": 257356,
-      "SizeOfInstalledFiles": 145826655110
+      "Hash": "2TSxhNv1zcA=",
+      "Size": 1252830023,
+      "NumberOfArchives": 967,
+      "SizeOfArchives": 107828106638,
+      "NumberOfInstalledFiles": 186612,
+      "SizeOfInstalledFiles": 144728057601
     },
     "version": "2.2.5.13",
     "dateCreated": "1970-01-01T00:00:00Z",


### PR DESCRIPTION
## 2.3.6: Vampiric Power
This release swaps out Curse of the Vampire for Sacrilege. Due to this, it is not savefile safe. I would recommend starting a new save or not updating your install if you intend to keep the same install. This change should make vampire playthroughs more satisfying. 

Additionally, this update fixes the crashes related to the Ancient Frost Atronach. This allows for proper completion of Dawnguard. Thank you to Rixban for his help with solving this issue. 

### Mods Added
- Sacrilege - Minimalistic Vampires of Skyrim 2.1.0

### Mods Removed
- Curse of the Vampire

### Patches Updated
- RGE General Patch