### PR TITLE
Update modlists.json

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -587,18 +587,18 @@
     "links": {
       "image": "https://raw.githubusercontent.com/SudoDoubleDog/rge/master/extra/rge.png",
       "readme": "https://raw.githubusercontent.com/lexcia98/rge/master/README.md",
-      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_e223cf84-e6ca-4368-b278-0ebe392506b7",
+      "download": "https://authored-files.wabbajack.org/Relics%20of%20Hyrule%20-%20GAT%20Edition.wabbajack_99195f16-34c5-4ae5-b16c-835cc3a539d0",
       "machineURL": "rge"
     },
     "download_metadata": {
-      "Hash": "2TSxhNv1zcA=",
-      "Size": 1252830023,
+      "Hash": "nkxKT9IShnU=",
+      "Size": 1254222944,
       "NumberOfArchives": 967,
       "SizeOfArchives": 107828106638,
-      "NumberOfInstalledFiles": 186612,
-      "SizeOfInstalledFiles": 144728057601
+      "NumberOfInstalledFiles": 186617,
+      "SizeOfInstalledFiles": 144729861186
     },
-    "version": "2.3.6",
+    "version": "2.3.6.1",
     "dateCreated": "1970-01-01T00:00:00Z",
     "dateUpdated": "0001-01-01T00:00:00"
   },


### PR DESCRIPTION
Relics of Hyrule: Grand Admiral Thrawn Edition update 2.3.6.1
Fixes drawspeed of Froki's Bow. 
Resolves crash related to water mods.
Fixed Relics of Hyrule book in Dragonreach not spawning due to mod conflicts. (requires new save to see result, also available in the Blue Palace on existing saves)

Plans for next update
Add appropriate keywords to some items missing them, such as some alchemy ingredients. Thanks to Rux616 for the assistance in speeding up this task when I do it with a list of ones to look at and suggested changes.
Different ENB? Considering NAT.ENB III based on the difficulty of removing mods no longer needed due to the ENB change.  
