### PR TITLE
Force VNV down

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -379,7 +379,7 @@
     "nsfw": false,
     "utility_list": false,
     "image_contains_title": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "$type": "Links, Wabbajack.Lib",
       "image": "https://raw.githubusercontent.com/TDarkShadow/vivanewvegas-wabbajack/master/background.webp",


### PR DESCRIPTION
Patch emporium got deleted without notice so the list is in maintenance until the urls are switched to the new hub repo.