### PR TITLE
Revert "Corrected Repo URL"

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -23,6 +23,5 @@
  "AtomicWarfare": "https://raw.githubusercontent.com/Rage-GitHub/Atomic-Warfare/main/modlists.json",
  "NEFARAM":"https://raw.githubusercontent.com/ConsolidatedSky/NEFARAM/main/modlists.json",
  "Draz&Dark": "https://raw.githubusercontent.com/DrazAndDarkModding/mod-lists/main/modlists.json",
- "Ragleys-STR": "https://raw.githubusercontent.com/ragley/Ragleys-STR/main/modlists.json",
- "Fable-Lore": "https://raw.githubusercontent.com/Rage-GitHub/Fable-Lore/main/modlists.json"
+ "Ragleys-STR": "https://raw.githubusercontent.com/ragley/Ragleys-STR/main/modlists.json" 
 }


### PR DESCRIPTION
Reverts wabbajack-tools/mod-lists#3154

something in this commit or the linked modlists.json still breaks the gallery.