### PR TITLE
Fix True Vegas repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -29,5 +29,5 @@
  "FUSION": "https://raw.githubusercontent.com/SpringHeelJon/FO4-FUSION/main/modlist.json",
  "HFT": "https://raw.githubusercontent.com/NotTotal/Happy-fun-times/main/modlists.json",
  "Apotheosis": "https://raw.githubusercontent.com/aljoxo/modlists/main/modlists.json",
- "TTWTrueVegas": "https://github.com/TheMrNewVegas/True-Vegas-TTW/raw/main/modlists.json"
+ "TTWTrueVegas": "https://raw.githubusercontent.com/TheMrNewVegas/True-Vegas-TTW/main/modlists.json"
 }


### PR DESCRIPTION
Lartza — 2022/09/14 at 10:46 GMT
Welp that's a new way to break WJ
https://github.com/wabbajack-tools/mod-lists/blob/master/repositories.json#L32 needs to be changed to https://raw.githubusercontent.com/TheMrNewVegas/True-Vegas-TTW/main/modlists.json
Or CORS changed on the web server Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://github.com/TheMrNewVegas/True-Vegas-TTW/raw/main/modlists.json. (Reason: CORS header ‘Access-Control-Allow-Origin’ does not match ‘https://render.githubusercontent.com’).