### PR TITLE
Updating Modlist Repos

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -20,16 +20,15 @@
  "tw3mw": "https://raw.githubusercontent.com/jdsmith2816/tw3mw/main/modlists.json",
  "ForgottenGlory": "https://raw.githubusercontent.com/ForgottenGlory/modlists/main/modlists.json",
  "frosty": "https://raw.githubusercontent.com/screaminglake/frosty/main/modlists.json",
- "AtomicWarfare": "https://raw.githubusercontent.com/Rage-GitHub/Atomic-Warfare/main/modlists.json",
  "NEFARAM":"https://raw.githubusercontent.com/ConsolidatedSky/NEFARAM/main/modlists.json",
  "Draz&Dark": "https://raw.githubusercontent.com/DrazAndDarkModding/mod-lists/main/modlists.json",
  "Ragleys-STR": "https://raw.githubusercontent.com/ragley/Ragleys-STR/main/modlists.json",
- "Fable-Lore": "https://raw.githubusercontent.com/Rage-GitHub/Fable-Lore/main/modlists.json",
  "groundzero": "https://raw.githubusercontent.com/screaminglake/groundzero/main/modlists.json",
  "FUSION": "https://raw.githubusercontent.com/SpringHeelJon/FO4-FUSION/main/modlist.json",
  "HFT": "https://raw.githubusercontent.com/NotTotal/Happy-fun-times/main/modlists.json",
  "Arisen": "https://raw.githubusercontent.com/aljoxo/modlists/main/modlists.json",
  "TTWTrueVegas": "https://raw.githubusercontent.com/TheMrNewVegas/True-Vegas-TTW/main/modlists.json",
  "licentia_black": "https://raw.githubusercontent.com/cacophony-wj/licentia_black/main/modlists.json",
- "CDPR_Modlists": "https://raw.githubusercontent.com/JustThatKing/CDPR-Modlists/main/modlists.json"
+ "CDPR_Modlists": "https://raw.githubusercontent.com/JustThatKing/CDPR-Modlists/main/modlists.json",
+ "Modding-Lounge": "https://raw.githubusercontent.com/Rage-GitHub/Modding-Lounge/main/modlists.json"
 }


### PR DESCRIPTION
Removed:
- Atomic Warfare Repo
- Fable Lore Repo

Combined AW and FL repos into one with Cyber Runner (WIP) modlist into one repo.