### PR TITLE
Remove Witcher 3 My Way

### DIFF
--- a/featured_lists.json
+++ b/featured_lists.json
@@ -14,7 +14,6 @@
   "WhisperingChills/Whispering-Chills",
   "ex0tek/diabolist_vr",
   "Animonculory/BOR",
-  "tw3mw/tw3mw",
   "LW/LW",
   "TTC/TTC",
   "LostOutpost/lostlegacy",


### PR DESCRIPTION
since @jdsmith2816  has no time to support it and it can't be installed at this time. it can be reinstated if he wants to bring it back, but since the support channel are closed this will remove/hide it on the Gallery