### PR TITLE
Update featured_lists.json

### DIFF
--- a/featured_lists.json
+++ b/featured_lists.json
@@ -12,7 +12,6 @@
   "LostOutpost/dragonborn",
   "LostOutpost/ro",
   "LostOutpost/thepath",
-  "Tahrovin/tahrovin",
   "WhisperingChills/Whispering-Chills",
   "ex0tek/diabolist_vr",
   "Animonculory/BOR",


### PR DESCRIPTION
Push Tahrovin back down to non-featured post-sunsetting. Removal from UI will happen once the list becomes uninstallable.