### PR TITLE
Remove Fahdon from featured

### DIFF
--- a/featured_lists.json
+++ b/featured_lists.json
@@ -1,7 +1,6 @@
 [
   "Keizaal/keizaal",
   "Wildlander/wildlander",
-  "Animonculory/fahdon",
   "Animonculory/ANVIL",
   "LostOutpost/ro",
   "LostOutpost/thepath",


### PR DESCRIPTION
Due to the whole paid mods ordeal, I've lost all motivation to continue modding as a passion. I have no plans to update fahdon, so I would like to remove it from being featured.