### PR TITLE
Force down TBV until updated for SDV 1.6

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -980,7 +980,7 @@
     "utility_list": false,
     "image_contains_title": true,
     "DisplayVersionOnlyInInstallerView": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "image": "https://raw.githubusercontent.com/Yagisan/The-Bustling-Valley/main/assets/images/TBV_Title.webp",
       "readme": "https://raw.githubusercontent.com/Yagisan/The-Bustling-Valley/main/README.md",


### PR DESCRIPTION
This list is not runnable with Stardew Valley 1.6, so force it down until both it, and the mods it uses are compatible with the new update.