### PR TITLE
Revert "Added new repo location for Modding Lounge"

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -47,7 +47,7 @@
   "Little_Bit_of_Everything": "https://raw.githubusercontent.com/Ferroxius/LBOE/main/modlists.json",
   "HoS": "https://raw.githubusercontent.com/CamIce2002/HallsofSovngarde/main/modlists.json",
   "Moonshadow": "https://raw.githubusercontent.com/Qolore7/modlists/main/modlists.json",
-  "Modding-Lounge": "https://files.moddinglounge.com/Rage/Modlists/raw/branch/main/Modlists.json",
+  "Modding-Lounge": "https://raw.githubusercontent.com/Rage-GitHub/Modding-Lounge/main/Modlists.json",
   "Below-Zero": "https://raw.githubusercontent.com/St1ck2k/FROST---Below-Zero-Fallout-4-Wabbajack-Modlist/main/modlists.json",
   "Mad_Gods_Overhaul": "https://raw.githubusercontent.com/Moyse06/MadGodsOverhaul/main/modlists.json",
   "Heartland": "https://raw.githubusercontent.com/TDarkShadow/heartland/master/heartland.wabbajack.json",


### PR DESCRIPTION
Reverts wabbajack-tools/mod-lists#3473

this sadly needs to be reverted because it does break the gallery. 
was very sure that it should have "just worked". 