### PR TITLE
Update repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -62,5 +62,5 @@
   "Palette": "https://raw.githubusercontent.com/Ferroxius/Palette/main/modlists.json",
   "FILFY": "https://raw.githubusercontent.com/AllstaRawR/FILFY/main/modlists.json",
   "Thuldor": "https://raw.githubusercontent.com/JWoolley00/Thuldors-Skyrim/main/modlists.json",
-  "Listonomicon": "https://raw.githubusercontent.com/ajaxxxxxxxx/Listonomicon/main/modlists.json"
+  "Listonomicon": "https://raw.githubusercontent.com/Listonomicon-Team/Listonomicon/main/modlists.json"
 }


### PR DESCRIPTION
Replace outdated personal github repo link to the Listonomicon Team link https://raw.githubusercontent.com/Listonomicon-Team/Listonomicon/main/modlists.json.