### PR TITLE
Force down Welcome to Paradise

### DIFF
--- a/modlists.json
+++ b/modlists.json
@@ -540,7 +540,7 @@
     "utility_list": false,
     "image_contains_title": true,
     "DisplayVersionOnlyInInstallerView": false,
-    "force_down": false,
+    "force_down": true,
     "links": {
       "image": "https://raw.githubusercontent.com/foreverphoenix/the-phoenix-flavour/wtp-dev/static/Pictures/wtp-2-1-cover.webp",
       "readme": "https://raw.githubusercontent.com/wabbajack-tools/mod-lists/master/phoenix-flavour-fo4/readme.md",


### PR DESCRIPTION
Forcing down Welcome To Paradise until the modlist gets recompiled with Wabbajack v3.7.0.0 (or newer) and Fallout 4 NG update.
