### PR TITLE
Force down FUSION

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -13,7 +13,7 @@
   "SS2CPC": "https://raw.githubusercontent.com/Yagisan/SS2-City-Plan-Contest-Helper/main/modlists.json",
   "ForgottenGlory": "https://raw.githubusercontent.com/ForgottenGlory/modlists/main/modlists.json",
   "NEFARAM":"https://raw.githubusercontent.com/ConsolidatedSky/NEFARAM/main/modlists.json",
-  "FUSION": "https://raw.githubusercontent.com/SpringHeelJon/FO4-FUSION/main/modlist.json",
+  "FUSION": "https://raw.githubusercontent.com/TDarkShadow/FO4-FUSION/force-down/FUSION/modlist.json",
   "TTWTrueVegas": "https://raw.githubusercontent.com/TheMrNewVegas/True-Vegas-TTW/main/modlists.json",
   "licentia_black": "https://raw.githubusercontent.com/cacophony-wj/licentia_black/main/modlists.json",
   "CDPR_Modlists": "https://raw.githubusercontent.com/JustThatKing/CDPR-Modlists/main/modlists.json",


### PR DESCRIPTION
Forcing down FUSION until the modlist gets recompiled with Wabbajack v3.7.0.0 (or newer) and Fallout 4 NG update.
