### PR TITLE
Remove Thuldor Skyrim

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -50,7 +50,6 @@
   "WastelandReborn": "https://raw.githubusercontent.com/Camora0/Wasteland-Reborn/main/modlists.json",
   "Palette": "https://raw.githubusercontent.com/Ferroxius/Palette/main/modlists.json",
   "FILFY": "https://raw.githubusercontent.com/AllstaRawR/FILFY/main/modlists.json",
-  "Thuldor": "https://raw.githubusercontent.com/JWoolley00/Thuldors-Skyrim/main/modlists.json",
   "Listonomicon": "https://raw.githubusercontent.com/Listonomicon-Team/Listonomicon/main/modlists.json",
   "PISE": "https://raw.githubusercontent.com/VirtualPandaVR/Panda-s-Immersive-SkyrimVR-Experience/main/modlists.json",
   "Draz_and_Darks_Modding_Hub": "https://raw.githubusercontent.com/DrazDarkModdingHub/DD_modlists/main/modlists.json",


### PR DESCRIPTION
Unsupported for the past 2 weeks, will not fix the troublesome installation until their next update.
> thank you for your messages, I'm aware of the issue and have been working on a 2.0 update for the last two months, which will fix installation. Please be patient until that releases
https://github.com/JWoolley00/Thuldors-Skyrim/issues/2