### PR TITLE
Update featured_lists.json

### DIFF
--- a/featured_lists.json
+++ b/featured_lists.json
@@ -38,5 +38,6 @@
   "Listonomicon/Listonomicon",
   "Palette/Alpyne",
   "BG3EE/BG3EE",
-  "UraniumFever/UraniumFever"
+  "UraniumFever/UraniumFever",
+  "NGVO/DNGG"
 ]


### PR DESCRIPTION
DNGG is now hosted in the Bungalo.