### PR TITLE
Remove Pickysaurus modlist URL

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -111,7 +111,6 @@
   "Lyra": "https://raw.githubusercontent.com/iyreshot/Modlist/main/modlists.json",
   "CSVP": "https://raw.githubusercontent.com/Colloquy99/CSVP/main/modlists.json",
   "Smorgasbord": "https://raw.githubusercontent.com/Fluffernuttersandwich/Smorgasbord/main/modlists.json",
-  "Pickysaurus": "https://raw.githubusercontent.com/Pickysaurus/Wabbajack-Test-Lists/main/modlists.json",
   "librum": "https://raw.githubusercontent.com/apoapse1/Librum-for-Skyrim-VR/main/modlists.json",
   "AscendedFates": "https://raw.githubusercontent.com/FatalSuccubusGaming/AscendedFatesModlist/main/modlists.json",
   "TAL": "https://raw.githubusercontent.com/CerberusX1/modlists/main/modlist.json",


### PR DESCRIPTION
Removed the Pickysaurus modlist URL from repositories.json.
This was just for testing the collection export process from a stardew valley list