### PR TITLE
Temporarily force down OldNewEngland

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -93,7 +93,6 @@
   "Krosis": "https://raw.githubusercontent.com/InWaveless/Krosis/main/modlists.json",
   "TheSICKnastySuite": "https://raw.githubusercontent.com/KCisSICKnasty/sicknasty-suite/main/modlist.json",
   "Scrolls_of_Schtevie": "https://raw.githubusercontent.com/HerrSchtevie/Scrolls-of-Schtevie/main/modlists.json",
-  "Kahnezzer": "https://raw.githubusercontent.com/Kahnezzer/OldNewEngland/main/modlist.json",
   "SkyrimUnificationProject": "https://raw.githubusercontent.com/skyrimunificationproject/SUP/main/modlists.json",
   "Gate_to_Sovngarde": "https://raw.githubusercontent.com/FlimsyParking/Gate-to-Sovngarde-Wabbajack/main/modlists.json",
   "True_North": "https://raw.githubusercontent.com/TrumanGIT/True-North/main/modlists.json",

--- a/unlisted_modlists.json
+++ b/unlisted_modlists.json
@@ -1,3 +1,42 @@
 [
-
+    {
+        "title": "Old New England",
+        "description": "Old New England is a modlist built for the players, not the creator. With over 1,000 mods, it's grounded in organization and stability. It's Fallout 4 with smarter systems, better encounters, and a world that truly feels alive. Every area has been improved and expanded, but without the unnecessary bloat. Ultimately, it\u2019s about bringing the Commonwealth to life in a way that feels fresh.",
+        "author": "Kahnezzer",
+        "maintainers": [
+            "github/Kahnezzer"
+        ],
+        "game": "fallout4",
+        "official": false,
+        "tags": [
+            "Steam",
+            "Total Overhaul"
+        ],
+        "nsfw": false,
+        "utility_list": false,
+        "image_contains_title": false,
+        "DisplayVersionOnlyInInstallerView": false,
+        "force_down": true,
+        "links": {
+            "image": "https://raw.githubusercontent.com/Kahnezzer/oldnewenglandresources/refs/heads/main/ONEcover.jpg",
+            "readme": "https://github.com/Kahnezzer/OldNewEngland/blob/main/README.md",
+            "download": "https://authored-files.wabbajack.org/ONE.wabbajack_93bdf138-3232-4c44-91c9-77c611c802ec",
+            "machineURL": "OldNewEngland",
+            "discordURL": "https://discord.gg/nxnqZyUf55",
+            "websiteURL": "https://github.com/Kahnezzer/OldNewEngland/blob/main/README.md"
+        },
+        "download_metadata": {
+            "Hash": "8f4RFUD2wiM=",
+            "Size": 334255825,
+            "NumberOfArchives": 1264,
+            "SizeOfArchives": 166636844824,
+            "NumberOfInstalledFiles": 138769,
+            "SizeOfInstalledFiles": 188785993696,
+            "TotalSize": 355422838520
+        },
+        "version": "1.2",
+        "dateCreated": "1970-01-01T00:00:00Z",
+        "dateUpdated": "2026-01-08T14:28:24.1670832Z",
+        "repositoryName": ""
+    }
 ]


### PR DESCRIPTION
On the request of [OMKdear](https://discord.com/channels/@me/1514188889592565860), temporarily force down the modlist so people know the modlist isn't currently installable.
<img width="753" height="1041" alt="image" src="https://github.com/user-attachments/assets/e5597f03-4b1b-4f24-b6a1-0f3a708087f6" />

To bring back the modlist, kindly revert the changes made in this PR / commit, and edit the repository to the desired one.